### PR TITLE
Add support of MSVC compiler

### DIFF
--- a/msvc-2017/Dockerfile
+++ b/msvc-2017/Dockerfile
@@ -1,0 +1,16 @@
+
+FROM microsoft/windowsservercore:1709
+
+RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+# wait for vs_installer.exe, vs_installerservice.exe
+# or vs_installershell.exe because choco doesn't
+RUN powershell -NoProfile -InputFormat None -Command \
+    choco install python -y --params "/InstallDir:C:\tools\python3"; \
+    choco install python2 -y --params "/InstallDir:C:\tools\python2"; \
+    choco install visualcpp-build-tools \
+        --version 15.0.26228.20170424 -y; \
+    Write-Host 'Waiting for Visual C++ Build Tools to finish'; \
+    Wait-Process -Name vs_installer
+
+CMD powershell -ExecutionPolicy Bypass

--- a/msvc-2017/user-config.jam
+++ b/msvc-2017/user-config.jam
@@ -1,0 +1,17 @@
+using msvc ;
+
+using python
+: 2.7 # version
+: # Interpreter/path to dir
+: c:\\tools\\python2\\include # includes
+: c:\\tools\\python2\\libs # libs
+: # conditions
+;
+
+using python 
+: 3.5 # version
+: # Interpreter/path to dir
+: c:\\tools\\python3\\include # includes
+: c:\\tools\\python3\\libs # libs
+: # conditions
+;


### PR DESCRIPTION
I can build Boost with this image, wondering what I could improve in this `Dockerfile` and `user-config.jam` file.

I get a lot of `BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE` warning from the compilation. Wondering how I can remove it inside that `user-config.jam` if possible.

Looking at more documentation it looks like that windows is using `project-config.jam` instead?