### PR TITLE
Using the new trusty base for 4.6 and 4.7

### DIFF
--- a/gcc-4.6/Dockerfile
+++ b/gcc-4.6/Dockerfile
@@ -3,8 +3,7 @@ MAINTAINER Thomas Kent <teeks99@yahoo.com>
 
 # Enable future toolchain PPA
 RUN apt-get update \
- && apt-get install -y python-software-properties \
- && add-apt-repository -y ppa:git-core/ppa \
+ && apt-get install -y software-properties-common \
 
 # Install pre-reqs
  && apt-get update \
@@ -15,8 +14,8 @@ RUN apt-get update \
   python \
   python2.7 \
   python2.7-dev \
-  python3.2 \
-  python3.2-dev \
+  python3.4 \
+  python3.4-dev \
   libbz2-dev \
   zlib1g-dev
 

--- a/gcc-4.6/user-config.jam
+++ b/gcc-4.6/user-config.jam
@@ -1,3 +1,4 @@
+using gcc : 4.8 : g++-4.8 : ;
 using gcc : 4.6 : g++-4.6 : ;
 using gcc : 4.6~c++98 : g++-4.6 : <cxxflags>"-std=c++98" ;
 using gcc : 4.6~c++98~O2 : g++-4.6 : <cxxflags>"-std=c++98 -O2" ;
@@ -17,15 +18,15 @@ using python
 : 2.7 # version
 : # Interpreter/path to dir
 : /usr/include/python2.7 # includes
-: /usr/lib # libs
+: /usr/lib/x86_64-linux-gnu # libs
 : # conditions
 ;
 
 using python 
-: 3.2 # version
+: 3.4 # version
 : # Interpreter/path to dir
-: /usr/include/python3.2 # includes
-: /usr/lib # libs
+: /usr/include/python3.4 # includes
+: /usr/lib/x86_64-linux-gnu # libs
 : # conditions
 ;
 

--- a/gcc-4.7/Dockerfile
+++ b/gcc-4.7/Dockerfile
@@ -3,9 +3,7 @@ MAINTAINER Thomas Kent <teeks99@yahoo.com>
 
 # Enable future toolchain PPA
 RUN apt-get update \
- && apt-get install -y python-software-properties \
- && add-apt-repository -y ppa:git-core/ppa \
- && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get install -y software-properties-common \
 
 # Install pre-reqs
  && apt-get update \
@@ -16,9 +14,10 @@ RUN apt-get update \
   python \
   python2.7 \
   python2.7-dev \
-  python3.2 \
-  python3.2-dev \
+  python3.4 \
+  python3.4-dev \
   libbz2-dev \
   zlib1g-dev
 
+# Add the tool configs
 ADD user-config.jam /

--- a/gcc-4.7/user-config.jam
+++ b/gcc-4.7/user-config.jam
@@ -1,3 +1,4 @@
+using gcc : 4.8 : g++-4.8 : ;
 using gcc : 4.7 : g++-4.7 : ;
 using gcc : 4.7~c++98 : g++-4.7 : <cxxflags>"-std=c++98" ;
 using gcc : 4.7~c++98~O2 : g++-4.7 : <cxxflags>"-std=c++98 -O2" ;
@@ -23,15 +24,15 @@ using python
 : 2.7 # version
 : # Interpreter/path to dir
 : /usr/include/python2.7 # includes
-: /usr/lib # libs
+: /usr/lib/x86_64-linux-gnu # libs
 : # conditions
 ;
 
 using python 
-: 3.2 # version
+: 3.4 # version
 : # Interpreter/path to dir
-: /usr/include/python3.2 # includes
-: /usr/lib # libs
+: /usr/include/python3.4 # includes
+: /usr/lib/x86_64-linux-gnu # libs
 : # conditions
 ;
 


### PR DESCRIPTION
This allows the bjam build step to be done with gcc 4.8, which is
the new minimum.